### PR TITLE
Delete Generated data BugFixing

### DIFF
--- a/inc/init/settings.php
+++ b/inc/init/settings.php
@@ -30,7 +30,9 @@ add_action(
 				$query_posts = new \WP_Query(
 					array(
 						'post_type' => 'any',
-						'nopaging' => false,
+						'post_status' => 'any',
+						'nopaging' => true,
+						'fields' => 'ids',
 						// @codingStandardsIgnoreStart | Still have to debug why this happens...
 						'meta_query' => array(
 						// @codingStandardsIgnoreEnd
@@ -42,9 +44,8 @@ add_action(
 						),
 					)
 				);
-				foreach ( $query_posts->posts as $post ){
-					$refs->post[] = absint( $post->ID );
-				}
+
+				$refs->post = array_map( 'absint' , $query_posts->posts );
 
 				$query_comments = new \WP_Comment_Query;
 				$query_comments = $query_comments->query(
@@ -79,7 +80,7 @@ add_action(
 						),
 					)
 				);
-				$refs->user = array_map( 'intval', $query_users->results );
+				$refs->user = array_map( 'absint', $query_users->results );
 
 				foreach ( $refs as $module => $ref ){
 					switch ( $module ) {

--- a/view/posts.php
+++ b/view/posts.php
@@ -76,9 +76,9 @@ $_json_comment_status_output = array(
 					<th scope="row"><label for="fakerpress_qty"><?php _e( 'Quantity', 'fakerpress' ); ?></label></th>
 					<td>
 						<div id="fakerpress[qty]" class='fakerpress_qty_range'>
-							<input style='width: 90px;' class='qty-range-min' type='number' max='25' min='1' placeholder='<?php esc_attr_e( 'e.g.: 1', 'fakerpress' ); ?>' value='' name='fakerpress_qty_min' />
+							<input style='width: 90px;' class='qty-range-min' type='number' min='1' placeholder='<?php esc_attr_e( 'e.g.: 1', 'fakerpress' ); ?>' value='' name='fakerpress_qty_min' />
 							<div class="dashicons dashicons-arrow-right-alt2 dashicon-date" style="display: inline-block;"></div>
-							<input style='width: 90px;' class='qty-range-max' type='number' max='25' min='1' placeholder='<?php esc_attr_e( 'e.g.: 10', 'fakerpress' ); ?>' value='' name='fakerpress_qty_max' disabled/>
+							<input style='width: 90px;' class='qty-range-max' type='number' min='1' placeholder='<?php esc_attr_e( 'e.g.: 10', 'fakerpress' ); ?>' value='' name='fakerpress_qty_max' disabled/>
 						</div>
 						<p class="description"><?php _e( 'The range of Posts you want to generate', 'fakerpress' ); ?></p>
 					</td>


### PR DESCRIPTION
When you tried to delete everything from with FakerPress there was a bug that only the maximum amount deleted was the default `posts_per_page`. Now it's fixed and I improved the Code to be a bit faster.
