### PR TITLE
Resolving Date Duplicating action

### DIFF
--- a/ui/js/fields.js
+++ b/ui/js/fields.js
@@ -347,7 +347,14 @@ window.fakerpress.fields.range = function( $, _ ){
 						$conf_container = $meta.find( _meta_conf_container ),
 						$fields = $meta.find( _fields ),
 
-						$template = $( '.fp-template-' + type ).filter( '[data-rel="' + $container.attr( 'id' ) + '"]' ).filter( '[data-callable]' );
+						$template;
+
+					// Before constructing the Type Object check if it's a jQuery element (Select2 bug)
+					if ( type instanceof jQuery ){
+						type = type.val();
+					}
+					$template = $( '.fp-template-' + type ).filter( '[data-rel="' + $container.attr( 'id' ) + '"]' ).filter( '[data-callable]' );
+
 
 					// Change the index first
 					$index.val( index + 1 );


### PR DESCRIPTION
When dealing with Select2 we need to take extra-care because it may return an instance of a jQuery element when doing `$el.select2('val')`.
