### PR TITLE
handle WP_Error on term creation

### DIFF
--- a/modules/term.php
+++ b/modules/term.php
@@ -32,6 +32,9 @@ class Term extends Base {
 		);
 
 		$term_object = wp_insert_term( $params['name'], $params['taxonomy'], $args );
+		if ( is_wp_error( $term_object ) ) {
+			return false;
+		}
 
 		$flagged = get_option( 'fakerpress.module_flag.' . $this->slug, array() );
 


### PR DESCRIPTION
If a term is created with a name matching an existing term, wp_insert_term
will return a WP_Error object instead of an array. In that case,
Term::do_save() should return false instead of causing a fatal error.