### PR TITLE
New Excluding Items Methods

### DIFF
--- a/inc/class-fp-admin.php
+++ b/inc/class-fp-admin.php
@@ -594,12 +594,13 @@ class Admin {
 		$modules = array( 'post', 'term', 'comment', 'user' );
 
 		foreach ( $modules as $module ){
-			$class_name = 'Module\\' . ucfirst( $module );
+			$class_name = '\FakerPress\Module\\' . ucfirst( $module );
+
 			if ( ! class_exists( $class_name ) ) {
 				continue;
 			}
 
-			$items = call_user_func_array( $class_name . '::fetch' );
+			$items = call_user_func_array( $class_name . '::fetch', array() );
 			$deleted = call_user_func_array( $class_name . '::delete', array( $items ) );
 		}
 

--- a/modules/comment.php
+++ b/modules/comment.php
@@ -29,6 +29,71 @@ class Comment extends Base {
 		return '<a href="' . esc_url( get_edit_comment_link( $id ) ) . '">' . absint( $id ) . '</a>';
 	}
 
+	/**
+	 * Fetches all the FakerPress related comments
+	 * @return array IDs of the comments
+	 */
+	public static function fetch() {
+		$query_comments = new \WP_Comment_Query;
+		$query_comments = $query_comments->query(
+			array(
+				'meta_query' => array(
+					array(
+						'key' => self::$flag,
+						'value' => true,
+						'type' => 'BINARY',
+					),
+				),
+			)
+		);
+
+		foreach ( $query_comments as $comment ){
+			$comments[] = absint( $comment->comment_ID );
+		}
+
+		return $comments;
+	}
+
+	/**
+	 * Use this method to prevent excluding something that was not configured by FakerPress
+	 *
+	 * @param  array|int|\WP_Comment $comment The ID for the Post or the Object
+	 * @return bool
+	 */
+	public static function delete( $comment ) {
+		if ( is_array( $comment ) ) {
+			$deleted = array();
+
+			foreach ( $comment as $id ) {
+				$id = $id instanceof \WP_Comment ? $id->comment_ID : $id;
+
+				if ( ! is_numeric( $id ) ) {
+					continue;
+				}
+
+				$deleted[ $id ] = self::delete( $id );
+			}
+
+			return $deleted;
+		}
+
+		if ( is_numeric( $comment ) ) {
+			$comment = \WP_Comment::get_instance( $comment );
+		}
+
+		if ( ! $comment instanceof \WP_Comment ) {
+			return false;
+		}
+
+		$flag = (bool) get_comment_meta( $comment->comment_ID, self::$flag, true );
+
+		if ( true !== $flag ) {
+			return false;
+		}
+
+		return wp_delete_comment( $comment->comment_ID, true );
+	}
+
 	public function do_save( $return_val, $data, $module ) {
 		$comment_id = wp_insert_comment( $data );
 

--- a/modules/comment.php
+++ b/modules/comment.php
@@ -34,6 +34,8 @@ class Comment extends Base {
 	 * @return array IDs of the comments
 	 */
 	public static function fetch() {
+		$comments = array();
+
 		$query_comments = new \WP_Comment_Query;
 		$query_comments = $query_comments->query(
 			array(

--- a/modules/term.php
+++ b/modules/term.php
@@ -29,6 +29,39 @@ class Term extends Base {
 		return absint( $id );
 	}
 
+	/**
+	 * Fetches all the FakerPress related Terms
+	 * @return array IDs of the Terms with
+	 */
+	public static function fetch() {
+		$terms = get_option( 'fakerpress.module_flag.term', array() );
+
+		return $terms;
+	}
+
+	/**
+	 * Use this method to prevent excluding something that was not configured by FakerPress
+	 *
+	 * @todo  Improve this to allow better checking
+	 *
+	 * @param  array $items The array of arrays, first level has taxonomy as keys, second level only ids
+	 * @return bool
+	 */
+	public static function delete( $items ) {
+		$deleted = array();
+		foreach ( $items as $taxonomy => $terms ){
+			$deleted[ $taxonomy ] = array();
+
+			foreach ( $terms as $term ){
+				$deleted[ $taxonomy ][ $term ] = wp_delete_term( $term, $taxonomy );
+			}
+		}
+
+		delete_option( 'fakerpress.module_flag.term' );
+
+		return $deleted;
+	}
+
 	public function do_save( $return_val, $data, $module ) {
 		$args = array(
 			'description' => $data['description'],


### PR DESCRIPTION
As [Paul Mckay reported on Twitter yesterday night on twitter](https://twitter.com/McKay_1988/status/700299519825723392), the excluding method can delete non-FakerPress items.

This Pull Request is to try to fix this #pieceofshit code that was this part of the plugin. :hankey: 



