### PR TITLE
Fixing User Flags not been set correctly

### DIFF
--- a/modules/user.php
+++ b/modules/user.php
@@ -80,7 +80,7 @@ class User extends Base {
 			return false;
 		}
 
-		$flag = (bool) get_post_meta( $user->ID, self::$flag, true );
+		$flag = (bool) get_user_meta( $user->ID, self::$flag, true );
 
 		if ( true !== $flag ) {
 			return false;
@@ -106,7 +106,7 @@ class User extends Base {
 		}
 
 		// Flag the Object as FakerPress
-		update_post_meta( $user_id, self::$flag, 1 );
+		update_user_meta( $user_id, self::$flag, 1 );
 
 		return $user_id;
 	}

--- a/modules/user.php
+++ b/modules/user.php
@@ -86,7 +86,7 @@ class User extends Base {
 			return false;
 		}
 
-		return wp_delete_post( $user->ID, true );
+		return wp_delete_user( $user->ID, get_current_user_id() );
 	}
 
 


### PR DESCRIPTION
As reported on #84 by @derpixler, we had a problem where users were not been registered as a FakerPress item.

The problem was bigger than that, because I found out that this bug was probably creating some posts been deleted for no apparent reason.