### PR TITLE
Allows Other Comment Types

### DIFF
--- a/modules/comment.php
+++ b/modules/comment.php
@@ -120,6 +120,7 @@ class Comment extends Base {
 
 		$comment_content_use_html = Variable::super( $request, array( 'use_html' ), FILTER_SANITIZE_STRING, 'off' ) === 'on';
 		$comment_content_html_tags = array_map( 'trim', explode( ',', Variable::super( $request, array( 'html_tags' ), FILTER_SANITIZE_STRING ) ) );
+		$comment_type = array_map( 'trim', explode( ',', Variable::super( $request, array( 'type' ), FILTER_SANITIZE_STRING ) ) );
 
 		$min_date = Variable::super( $request, array( 'interval_date', 'min' ) );
 		$max_date = Variable::super( $request, array( 'interval_date', 'max' ) );
@@ -131,6 +132,7 @@ class Comment extends Base {
 			$this->set( 'comment_date', $min_date, $max_date );
 			$this->set( 'comment_content', $comment_content_use_html, array( 'elements' => $comment_content_html_tags ) );
 			$this->set( 'user_id', 0 );
+			$this->set( 'comment_type', $comment_type );
 
 			$this->set( 'comment_author' );
 			$this->set( 'comment_parent' );

--- a/providers/wp-comment.php
+++ b/providers/wp-comment.php
@@ -41,9 +41,28 @@ class WP_Comment extends Base {
 		return absint( $comment_parent );
 	}
 
-	// @codingStandardsIgnoreStart | Because of the cammel casing on the name
+	/**
+	 * Generate a random comment type with the values given
+	 * Converts 'default' into an empty string for default post comments
+	 *
+	 * @since  0.4.8
+	 *
+	 * @param  array|string $comment_type Possible comment types to pick from
+	 *
+	 * @return string
+	 */
+	public function comment_type( $comment_type = null ) {
+		// Fetch a Random element from the possible comment types
+		$comment_type = $this->generator->randomElement( (array) $comment_type );
+
+		if ( 'default' === $comment_type || is_null( $comment_type ) ) {
+			$comment_type = '';
+		}
+
+		return $comment_type;
+	}
+
 	public function comment_author_IP( $ip = null ) {
-	// @codingStandardsIgnoreEnd
 		if ( is_null( $ip ) ){
 			$ip = $this->generator->ipv4;
 		}

--- a/readme.md
+++ b/readme.md
@@ -99,7 +99,8 @@ Thank you for wanting to make FakerPress better for everyone! [We salute you](ht
 ## Changelog ##
 
 ### 0.4.8 &mdash; TBD ###
-* Tweak: Added two new filters to Filter Meta Value `fakerpress.module.meta.value` and ``fakerpress.module.meta.{$key}.value`` - Thanks [@Mte90](https://github.com/bordoni/fakerpress/pull/111)
+* Feature: Now Comments can be generated with differnt types, allowing for WooCommerce Notes for example - Thanks [@dibbyo456](https://wordpress.org/support/topic/can-i-create-custom-comments/)
+* Tweak: Added two new filters to Filter Meta Value `fakerpress.module.meta.value` and `fakerpress.module.meta.{$key}.value` - Thanks [@Mte90](https://github.com/bordoni/fakerpress/pull/111)
 * Fix: Resolve problems on failed Meta generation - Thanks [@Mte90](https://github.com/bordoni/fakerpress/pull/110)
 * Fix: Typo on Provider text for Attachment Meta - Thanks [@codiceovvio](https://github.com/bordoni/fakerpress/pull/103)
 

--- a/readme.txt
+++ b/readme.txt
@@ -98,7 +98,8 @@ Thank you for wanting to make FakerPress better for everyone! [We salute you](ht
 
 = 0.4.8 &mdash; TBD =
 
-* Tweak: Added two new filters to Filter Meta Value `fakerpress.module.meta.value` and ``fakerpress.module.meta.{$key}.value`` - Thanks [@Mte90](https://github.com/bordoni/fakerpress/pull/111)
+* Feature: Now Comments can be generated with differnt types, allowing for WooCommerce Notes for example - Thanks [@dibbyo456](https://wordpress.org/support/topic/can-i-create-custom-comments/)
+* Tweak: Added two new filters to Filter Meta Value `fakerpress.module.meta.value` and `fakerpress.module.meta.{$key}.value` - Thanks [@Mte90](https://github.com/bordoni/fakerpress/pull/111)
 * Fix: Resolve problems on failed Meta generation - Thanks [@Mte90](https://github.com/bordoni/fakerpress/pull/110)
 * Fix: Typo on Provider text for Attachment Meta - Thanks [@codiceovvio](https://github.com/bordoni/fakerpress/pull/103)
 

--- a/view/comments.php
+++ b/view/comments.php
@@ -1,6 +1,46 @@
 <?php
 namespace FakerPress;
 
+global $wpdb;
+
+// Mount the options for post_types
+$comment_types = $wpdb->get_col( "SELECT `comment_type` FROM $wpdb->comments GROUP BY `comment_type`" );
+
+// Default is the Empty value
+$_json_comment_types_output = array(
+	array(
+		'id' => 'default',
+		'text' => esc_attr__( 'default', 'fakerpress' ),
+	),
+);
+
+foreach ( $comment_types as $comment ) {
+	// Skip the Default Option
+	if ( empty( $comment ) ) {
+		continue;
+	}
+
+	$_json_comment_types_output[] = array(
+		'id' => $comment,
+		'text' => $comment,
+	);
+}
+
+$fields[] = new Field(
+	'dropdown',
+	array(
+		'id' => 'type',
+		'multiple' => true,
+		'data-options' => $_json_comment_types_output,
+		'data-tags' => true,
+		'value' => 'default',
+	),
+	array(
+		'label' => __( 'Type', 'fakerpress' ),
+		'description' => __( 'Which type of comment are you going to generate?', 'fakerpress' ),
+	)
+);
+
 $fields[] = new Field(
 	'range',
 	'qty',


### PR DESCRIPTION
Based on a request from a User on the WordPress.org forums I am adding here this feature that will fit nicely with stuff like WooCommerce Notes.