### PR TITLE
Updated 'Tested up to' version

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      bordoni
 Tags:              generator, dummy content, dummy data, lorem ipsun, admin, exemples, testing, images, attachments, featured image, taxonomies, users, post type, faker, fake data, random, developer, dev, development, test, tests
 Requires at least: 3.7
-Tested up to:      4.9.4
+Tested up to:      5.2.2
 Stable tag:        trunk
 License:           GPLv2 or later
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
I use this plugin regularly, and noticed it's currently showing a "hasn’t been tested with the latest 3 major releases of WordPress" on the repo page, this should fix that.

If you need assistance maintaining/updating this plugin in the repo, I'm happy to help.

Cheers