### PR TITLE
Fixes order of parameters for fp_array_get function

### DIFF
--- a/src/FakerPress/Plugin.php
+++ b/src/FakerPress/Plugin.php
@@ -160,7 +160,7 @@ class Plugin {
 
 	public static function get( $name, $default = false ) {
 		$options = self::all();
-		$value = fp_array_get( $options, $name, $default );
+		$value = fp_array_get( $options, $name, null, $default );
 
 		return $value;
 	}

--- a/src/FakerPress/Template.php
+++ b/src/FakerPress/Template.php
@@ -209,7 +209,7 @@ class Template {
 			return $value;
 		}
 
-		return fp_array_get( $context, $index, $default );
+		return fp_array_get( $context, $index, null, $default );
 	}
 
 	/**

--- a/src/functions/array.php
+++ b/src/functions/array.php
@@ -60,12 +60,12 @@ function fp_array_set( array $array, $key, $value ) {
  * @param array        $variable Array or object to search within.
  * @param array|string $indexes Specify each nested index in order.
  *                                Example: array( 'lvl1', 'lvl2' );
- * @param mixed        $default Default value if the search finds nothing.
  * @param mixed        $filter  Filter the value for security reasons.
+ * @param mixed        $default Default value if the search finds nothing.
  *
  * @return mixed The value of the specified index or the default if not found.
  */
-function fp_array_get( $variable, $indexes, $default = null, $filter = null ) {
+function fp_array_get( $variable, $indexes, $filter = null, $default = null ) {
 	if ( is_object( $variable ) ) {
 		$variable = (array) $variable;
 	}
@@ -107,7 +107,7 @@ function fp_array_get( $variable, $indexes, $default = null, $filter = null ) {
  */
 function fp_array_get_in_any( array $variables, $indexes, $default = null ) {
 	foreach ( $variables as $variable ) {
-		$found = fp_array_get( $variable, $indexes, '__not_found__' );
+		$found = fp_array_get( $variable, $indexes, null, '__not_found__' );
 		if ( '__not_found__' !== $found ) {
 			return $found;
 		}


### PR DESCRIPTION
Fixes: #140 

The order of `default` and `filter` parameters have been reversed and function calls have been adjusted, so that in cases `default` has been 3rd parameter it is now the 4th and the 3rd has been set to `null`.