### PR TITLE
Fix: Undefined plugin_path property

### DIFF
--- a/src/FakerPress/Assets.php
+++ b/src/FakerPress/Assets.php
@@ -369,11 +369,11 @@ class Assets {
 			}
 		}
 
-		$path = $resource_path . $asset->file;
-		$file = wp_normalize_path( $asset->plugin_path . $path );
+		$resource = $resource_path . $asset->file;
+		$file     = wp_normalize_path( $asset->origin_path . $resource );
 
 		// Turn the Path into a URL
-		$url = plugins_url( $file, $asset->origin_file );
+		$url = plugins_url( $asset->file, $file );
 
 		/**
 		 * Filters the resource URL


### PR DESCRIPTION
When the admin pages of the plugin is access, we get the following fatal error saying undefined plugin_path property. This PR fixes the issue.

![Screenshot (1)](https://user-images.githubusercontent.com/8264719/97171106-f52f4500-17b4-11eb-8463-9324509a8635.png)
