### PR TITLE
Fix TypeError: Unsupported operand types: int + string

### DIFF
--- a/src/FakerPress/Provider/WP_User.php
+++ b/src/FakerPress/Provider/WP_User.php
@@ -16,7 +16,7 @@ class WP_User extends Base {
 	public function user_pass( $pass = null, $qty = 10 ) {
 		if ( is_null( $pass ) ) {
 			if ( function_exists( 'wp_generate_password' ) ) {
-				$pass = wp_generate_password();
+				$pass = wp_generate_password( $qty );
 			} else {
 				$pass = $this->generator->randomNumber( $qty - 1 ) . $this->generator->randomLetter();
 			}

--- a/src/FakerPress/Provider/WP_User.php
+++ b/src/FakerPress/Provider/WP_User.php
@@ -15,8 +15,11 @@ class WP_User extends Base {
 
 	public function user_pass( $pass = null, $qty = 10 ) {
 		if ( is_null( $pass ) ) {
-			// By the way we should be using the WordPress wp_generate_password
-			$pass = $this->generator->randomNumber( $qty - 1 ) + $this->generator->randomLetter();
+			if ( function_exists( 'wp_generate_password' ) ) {
+				$pass = wp_generate_password();
+			} else {
+				$pass = $this->generator->randomNumber( $qty - 1 ) . $this->generator->randomLetter();
+			}
 		}
 		return $pass;
 	}


### PR DESCRIPTION
I was running PHP 8.0 when I encountered the following error:

The error can be replicated by adding any sort of user and running PHP 8.

`[28-Jan-2021 16:08:37 UTC] PHP Fatal error:  Uncaught TypeError: Unsupported operand types: int + string in /Applications/MAMP/htdocs/wordpress/wp-content/plugins/fakerpress/src/FakerPress/Provider/WP_User.php:19
Stack trace:
#0 [internal function]: FakerPress\Provider\WP_User->user_pass()
#1 /Applications/MAMP/htdocs/wordpress/wp-content/plugins/fakerpress/vendor/fzaninotto/faker/src/Faker/Generator.php(228): call_user_func_array(Array, Array)
#2 /Applications/MAMP/htdocs/wordpress/wp-content/plugins/fakerpress/vendor/fzaninotto/faker/src/Faker/Generator.php(285): Faker\Generator->format('user_pass', Array)
#3 [internal function]: Faker\Generator->__call('user_pass', Array)
#4 /Applications/MAMP/htdocs/wordpress/wp-content/plugins/fakerpress/src/FakerPress/Module/Base.php(214): call_user_func_array(Array, Array)
#5 /Applications/MAMP/htdocs/wordpress/wp-content/plugins/fakerpress/src/FakerPress/Module/Base.php(191): FakerPress\Module\Base->apply(Object(stdClass))
#6 /Applications/MAMP/htdocs/wordpress/wp-content/plugins/fakerpress/src/FakerPress/Module/User.php(164): FakerPress\Module\Base->generate()
#7 /Applications/MAMP/htdocs/wordpress/wp-content/plugins/fakerpress/src/FakerPress/Ajax.php(76): FakerPress\Module\User->parse_request(2, Array)
#8 /Applications/MAMP/htdocs/wordpress/wp-includes/class-wp-hook.php(287): FakerPress\Ajax::module_generate('')
#9 /Applications/MAMP/htdocs/wordpress/wp-includes/class-wp-hook.php(311): WP_Hook->apply_filters('', Array)
#10 /Applications/MAMP/htdocs/wordpress/wp-includes/plugin.php(484): WP_Hook->do_action(Array)
#11 /Applications/MAMP/htdocs/wordpress/wp-admin/admin-ajax.php(184): do_action('wp_ajax_fakerpr...')
#12 {main}
  thrown in /Applications/MAMP/htdocs/wordpress/wp-content/plugins/fakerpress/src/FakerPress/Provider/WP_User.php on line 19`

The $pass variable's value will now be a result of the **wp_generate_password()** function, so long as the function exists. If the function does not exist, then the $pass variable's value will hold the random number and random letter created by the generator. However, the random number and random letter will be concatenated instead of being added together, due to type errors being raised in newer versions of PHP.