### PR TITLE
correct search_terms nonce name

### DIFF
--- a/src/FakerPress/Ajax.php
+++ b/src/FakerPress/Ajax.php
@@ -119,7 +119,7 @@ class Ajax {
 			]
 		);
 
-		if ( ! wp_verify_nonce( $request->nonce, Plugin::$slug . '-select-search_terms' ) ) {
+		if ( ! wp_verify_nonce( $request->nonce, Plugin::$slug . '-select2-search_terms' ) ) {
 			$response->message = esc_attr__( 'Invalid nonce verification', 'fakerpress' );
 
 			return ( is_ajax() ? exit( json_encode( $response ) ) : $response );


### PR DESCRIPTION
The created nonce name currently doesn't match with the wp_verify_nonce name causing term searching to fail

[bordoni/fakerpress@main/src/FakerPress/Field.php#L1009](https://github.com/bordoni/fakerpress/blob/main/src/FakerPress/Field.php?rgh-link-date=2024-04-03T01%3A14%3A34Z#L1009)