### PR TITLE
Enable the creation of Consistent Users

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -102,6 +102,8 @@ Thank you for wanting to make FakerPress better for everyone! [We salute you](ht
 = 0.6.2 &mdash; 22 of April 2024 =
 
 * Version - Updated composer dependency `fakerphp/faker` to version `1.23`.
+* Feature - Include consistent user generation, to avoid users feeling a disjointed props @helgatheviking
+* Tweak - Include the ability to regenerate module data, allowing us to fetch values from earlier generations.
 * Tweak - Include properly use Composer for autoloading and dependencies without conflicting with other plugins.
 * Tweak - Include `lucatume/di52` and `nesbot/carbon` Strauss dependencies, which prevents conflicts with other plugins.
 * Fix - Prevent namespace problems with nonexistent classes, specially around Exceptions.

--- a/src/FakerPress/Module/Abstract_Module.php
+++ b/src/FakerPress/Module/Abstract_Module.php
@@ -409,8 +409,12 @@ abstract class Abstract_Module implements Interface_Module {
 	/**
 	 * @inheritDoc
 	 */
-	public function generate(): Interface_Module {
+	public function generate( bool $force = false ): Interface_Module {
 		foreach ( $this->data as $name => $item ) {
+			if ( ! $force && $this->has_value( $name ) ) {
+				continue;
+			}
+
 			$this->data[ $name ]->value = $this->apply( $item );
 		}
 
@@ -446,5 +450,28 @@ abstract class Abstract_Module implements Interface_Module {
 		}
 
 		return $values;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function get( string $key ): ?object {
+		return $this->data[ $key ] ?? null;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function get_value( string $key ) {
+		$data = $this->get( $key );
+		return $data->value ?? null;
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public function has_value( string $key ): bool {
+		$data = $this->get( $key );
+		return isset( $data->value );
 	}
 }

--- a/src/FakerPress/Module/Interface_Module.php
+++ b/src/FakerPress/Module/Interface_Module.php
@@ -136,10 +136,13 @@ interface Interface_Module {
 	 * Use this method to generate all the needed data.
 	 *
 	 * @since 0.6.0
+	 * @since 0.6.2 Added the $force parameter.
+	 *
+	 * @param bool $force Whether to force the regeneration of the data.
 	 *
 	 * @return self
 	 */
-	public function generate(): Interface_Module;
+	public function generate( bool $force = false ): Interface_Module;
 
 	/**
 	 * A method to make it easier to debug which variables will be actually saved.
@@ -149,4 +152,31 @@ interface Interface_Module {
 	 * @return array
 	 */
 	public function get_values(): array;
+
+	/**
+	 * A method to get the data for a given key.
+	 *
+	 * @param string $key
+	 *
+	 * @return array|null
+	 */
+	public function get( string $key ): ?object;
+
+	/**
+	 * A method to get the value for a given key.
+	 *
+	 * @param string $key
+	 *
+	 * @return mixed
+	 */
+	public function get_value( string $key );
+
+	/**
+	 * Determines if a value is set for a given key.
+	 *
+	 * @param string $key
+	 *
+	 * @return bool
+	 */
+	public function has_value( string $key ): bool;
 }

--- a/src/FakerPress/Module/Meta.php
+++ b/src/FakerPress/Module/Meta.php
@@ -101,7 +101,12 @@ class Meta extends Abstract_Module {
 	/**
 	 * @inheritDoc
 	 */
-	public function generate(): Interface_Module {
+	public function generate( bool $force = false ): Interface_Module {
+		// Only regenerate if there is no data, or we are forcing it.
+		if ( isset( $this->data['meta_value'] ) && ! $force ) {
+			return $this;
+		}
+
 		// Allow a bunch of params
 		$arguments = func_get_args();
 

--- a/src/FakerPress/Module/User.php
+++ b/src/FakerPress/Module/User.php
@@ -158,16 +158,21 @@ class User extends Abstract_Module {
 			$this->set( 'user_registered', 'yesterday', 'now' );
 
 			$this->set( [
-				'user_login',
-				'user_pass',
-				'user_nicename',
-				'user_url',
-				'user_email',
-				'display_name',
-				'nickname',
 				'first_name',
 				'last_name',
+				'user_pass',
+				'user_url',
 			] );
+
+			$this->generate();
+
+			$username_from_generated_first_last = strtolower( implode( '.', [ $this->get_value( 'first_name' ), $this->get_value( 'last_name' ) ] ) );
+
+			$this->set( 'user_login', $username_from_generated_first_last );
+			$this->set( 'user_nicename', $username_from_generated_first_last );
+			$this->set( 'user_email', $username_from_generated_first_last . '@' . Faker\Provider\Internet::safeEmailDomain() );
+			$this->set( 'display_name', $this->get_value( 'first_name' ) );
+			$this->set( 'nickname', $username_from_generated_first_last );
 
 			$user_id = $this->generate()->save();
 

--- a/src/FakerPress/Provider/WP_User.php
+++ b/src/FakerPress/Provider/WP_User.php
@@ -8,14 +8,132 @@ use function FakerPress\make;
 
 class WP_User extends Base {
 
-	public function user_login( $login = null ) {
-		if ( is_null( $login ) ) {
-			$login = $this->generator->userName;
-		}
-		return $login;
+	/**
+	 * Returns a first name, if nothing was passed, it will generate a random one.
+	 *
+	 * @since 0.1.0
+	 * @since 0.6.2 Introduced type safety.
+	 *
+	 * @param string|null $first_name
+	 * @param string[]    $gender
+	 *
+	 * @return string|null
+	 */
+	public function first_name( ?string $first_name = null, array $gender = [ 'male', 'female' ] ): ?string {
+		return $first_name ?? $this->generator->firstName( $this->generator->randomElements( $gender, 1 ) );
 	}
 
-	public function user_pass( $pass = null, $qty = 10 ) {
+	/**
+	 * Returns a last name, if nothing was passed, it will generate a random one.
+	 *
+	 * @since 0.1.0
+	 * @since 0.6.2 Introduced type safety.
+	 *
+	 * @param string|null $last_name
+	 *
+	 * @return string|null
+	 */
+	public function last_name( ?string $last_name = null ): ?string {
+		return $last_name ?? $this->generator->lastName;
+	}
+
+	/**
+	 * Returns a random username, if nothing was passed, it will generate a random one.
+	 *
+	 * @since 0.1.0
+	 * @since 0.6.2 Introduced type safety.
+	 *
+	 * @param string|null $login
+	 *
+	 * @return string|null
+	 */
+	public function user_login( ?string $login = null ): ?string {
+		return $login ?? $this->generator->userName;
+	}
+
+	/**
+	 * Returns a random nicename, if nothing was passed, it will generate a random one.
+	 *
+	 * @since 0.1.0
+	 * @since 0.6.2 Introduced type safety.
+	 *
+	 * @param string|null $nicename
+	 *
+	 * @return string|null
+	 */
+	public function user_nicename( ?string $nicename = null ): ?string {
+		return $nicename ?? $this->generator->userName;
+	}
+
+	/**
+	 * Returns a random URL, if nothing was passed, it will generate a random one.
+	 *
+	 * @since 0.1.0
+	 * @since 0.6.2 Introduced type safety.
+	 *
+	 * @param string|null $url
+	 *
+	 * @return string|null
+	 */
+	public function user_url( ?string $url = null ): ?string {
+		return $url ?? $this->generator->url;
+	}
+
+	/**
+	 * Returns a random email, if nothing was passed, it will generate a random one.
+	 *
+	 * @since 0.1.0
+	 * @since 0.6.2 Introduced type safety.
+	 *
+	 * @param string|null $email
+	 *
+	 * @return string|null
+	 */
+	public function user_email( ?string $email = null ): ?string {
+		return $email ?? $this->generator->safeEmail;
+	}
+
+	/**
+	 * Returns a random display name, if nothing was passed, it will generate a random one.
+	 *
+	 * @since 0.1.0
+	 * @since 0.6.2 Introduced type safety.
+	 *
+	 * @param string|null $display_name
+	 * @param string[]    $gender
+	 *
+	 * @return string|null
+	 */
+	public function display_name( ?string $display_name = null, array $gender = [ 'male', 'female' ] ): ?string {
+		return $display_name ?? $this->generator->firstName( $this->generator->randomElements( $gender, 1 ) );
+	}
+
+	/**
+	 * Returns a random nickname, if nothing was passed, it will generate a random one.
+	 *
+	 * @since 0.1.0
+	 * @since 0.6.2 Introduced type safety.
+	 *
+	 * @param string|null $nickname
+	 *
+	 * @return string|null
+	 */
+	public function nickname( ?string $nickname = null ): ?string {
+		return $nickname ?? $this->generator->userName;
+	}
+
+	/**
+	 * Returns a random password, if nothing was passed, it will generate a random one.
+	 *
+	 * @since 0.1.0
+	 * @since 0.6.2 Introduced type safety.
+	 *
+	 * @param string|null $pass
+	 * @param int		 $qty
+	 *
+	 * @return string|null
+	 */
+	public function user_pass( ?string $pass = null, int $qty = 10 ): ?string {
 		if ( is_null( $pass ) ) {
 			if ( function_exists( 'wp_generate_password' ) ) {
 				$pass = wp_generate_password( $qty );
@@ -26,64 +144,18 @@ class WP_User extends Base {
 		return $pass;
 	}
 
-	public function role( $role = null ) {
-		if ( is_null( $role ) ) {
-			$role = array_keys( get_editable_roles() );
-		}
-
-		return $this->generator->randomElement( $role );
-	}
-
-	public function user_nicename( $nicename = null ) {
-		if ( is_null( $nicename ) ) {
-			$nicename = $this->generator->userName;
-		}
-		return $nicename;
-	}
-
-	public function user_url( $url = null ) {
-		if ( is_null( $url ) ) {
-			$url = $this->generator->url;
-		}
-		return $url;
-	}
-
-	public function user_email( $email = null ) {
-		if ( is_null( $email ) ) {
-			$email = $this->generator->safeEmail;
-		}
-		return $email;
-	}
-
-	public function display_name( $display_name = null, $gender = [ 'male', 'female' ] ) {
-		if ( is_null( $display_name ) ) {
-			$display_name = $this->generator->firstName( $this->generator->randomElements( $gender, 1 ) );
-		}
-		return $display_name;
-	}
-
-	public function nickname( $nickname = null ) {
-		if ( is_null( $nickname ) ) {
-			$nickname = $this->generator->userName;
-		}
-		return $nickname;
-	}
-
-	public function first_name( $first_name = null, $gender = [ 'male', 'female' ] ) {
-		if ( is_null( $first_name ) ) {
-			$first_name = $this->generator->firstName( $this->generator->randomElements( $gender, 1 ) );
-		}
-		return $first_name;
-	}
-
-	public function last_name( $last_name = null ) {
-		if ( is_null( $last_name ) ) {
-			$last_name = $this->generator->lastName;
-		}
-		return $last_name;
-	}
-
-	public function description( $html = true, $args = [] ) {
+	/**
+	 * Returns a random description.
+	 *
+	 * @since 0.1.0
+	 * @since 0.6.2 Introduced type safety.
+	 *
+	 * @param bool $html Whether to return HTML or plain text.
+	 * @param array $args
+	 *
+	 * @return string|null
+	 */
+	public function description( $html = true, $args = [] ): ?string {
 		$defaults = [
 			'qty' => [ 5, 15 ],
 		];
@@ -96,6 +168,20 @@ class WP_User extends Base {
 		}
 
 		return $content;
+	}
+
+	/**
+	 * Returns a random role, if nothing was passed, it will pick a random one from the available roles.
+	 *
+	 * @since 0.1.0
+	 * @since 0.6.2 Introduced type safety.
+	 *
+	 * @param string[] $role
+	 *
+	 * @return string
+	 */
+	public function role( array $role = [] ): string {
+		return $this->generator->randomElement( $role ?? array_keys( get_editable_roles() ) );
 	}
 
 	public function user_registered( $min = 'now', $max = null ) {


### PR DESCRIPTION
To allow us to get to consistent users in WordPress, we need to be able to generate certain values and then set some extra items and re-generate.

- Added type safety for `WP_User` provider of Fake data.
- Added a new param to `Module->generate()` to enable us to force regeneration
- Prevent generation of data that already has values by default
- Added a couple of supporting methods to the `Abstract_Module`