### PR TITLE
Update WP_User.php: harden user_pass method

### DIFF
--- a/src/FakerPress/Provider/WP_User.php
+++ b/src/FakerPress/Provider/WP_User.php
@@ -133,12 +133,12 @@ class WP_User extends Base {
 	 *
 	 * @return string|null
 	 */
-	public function user_pass( ?string $pass = null, int $qty = 10 ): ?string {
+	public function user_pass( ?string $pass = null, int $qty = 16 ): ?string {
 		if ( is_null( $pass ) ) {
 			if ( function_exists( 'wp_generate_password' ) ) {
-				$pass = wp_generate_password( $qty );
+				$pass = wp_generate_password( $qty, true );
 			} else {
-				$pass = $this->generator->randomNumber( $qty - 1 ) . $this->generator->randomLetter();
+				$pass = $this->generator->password( $qty );
 			}
 		}
 		return $pass;


### PR DESCRIPTION
This updates strength for wp_generate_password and fallback passwords. Now the minimum char count is 16, wp_generate_password also uses special characters. The fallback now uses Faker's password method which returns stronger passwords.