### PR TITLE
fix: restore date-type meta generation (missing Chronos import)

### DIFF
--- a/src/FakerPress/Provider/WP_Meta.php
+++ b/src/FakerPress/Provider/WP_Meta.php
@@ -2,6 +2,7 @@
 
 namespace FakerPress\Provider;
 
+use FakerPress\ThirdParty\Cake\Chronos\Chronos;
 use FakerPress\ThirdParty\Faker\Provider\Base;
 use FakerPress;
 use FakerPress\Utils;

--- a/src/FakerPress/Provider/WP_Post.php
+++ b/src/FakerPress/Provider/WP_Post.php
@@ -211,7 +211,9 @@ class WP_Post extends Base {
 		);
 
 		foreach ( $config as $settings ) {
-			$settings = (object) $settings;
+			$settings               = (object) $settings;
+			$settings->taxonomies ??= [];
+			$settings->terms      ??= [];
 
 			if ( ! empty( $settings->taxonomies ) && is_string( $settings->taxonomies ) ) {
 				$settings->taxonomies = explode( ',', $settings->taxonomies );

--- a/tests/wpunit/Provider/WP_MetaTest.php
+++ b/tests/wpunit/Provider/WP_MetaTest.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Tests for the WP_Meta Faker provider.
+ *
+ * Locks in the fix for the wp.org bug report:
+ * "Fatal error when using date option in meta field rules" where calling
+ * meta_type_date triggered "Class 'FakerPress\Provider\Chronos' not found"
+ * because Chronos was not imported into the file's namespace.
+ *
+ * @since 0.9.1
+ *
+ * @package FakerPress\Tests\Provider
+ */
+
+namespace FakerPress\Tests\Provider;
+
+use FakerPress\Provider\WP_Meta;
+use FakerPress\ThirdParty\Cake\Chronos\Chronos;
+use FakerPress\ThirdParty\Faker\Factory;
+use FakerPress\ThirdParty\Faker\Generator;
+
+/**
+ * Class WP_MetaTest
+ *
+ * @since 0.9.1
+ */
+class WP_MetaTest extends \Codeception\TestCase\WPTestCase {
+
+	/**
+	 * Build a Faker generator with the WP_Meta provider attached.
+	 *
+	 * @since 0.9.1
+	 *
+	 * @return Generator
+	 */
+	private function make_generator(): Generator {
+		$faker = Factory::create();
+		$faker->addProvider( new WP_Meta( $faker ) );
+
+		return $faker;
+	}
+
+	/**
+	 * Verify meta_type_date returns a formatted string inside the requested interval.
+	 *
+	 * @test
+	 */
+	public function it_should_generate_a_date_meta_value_with_default_format(): void {
+		$faker  = $this->make_generator();
+		$min    = '2020-01-01';
+		$max    = '2020-12-31';
+		$result = $faker->meta_type_date(
+			[
+				'min' => $min,
+				'max' => $max,
+			],
+			'Y-m-d H:i:s',
+			100
+		);
+
+		$this->assertIsString( $result );
+		$this->assertMatchesRegularExpression( '/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $result );
+
+		$generated = Chronos::parse( $result );
+		$this->assertTrue( $generated->greaterThanOrEquals( Chronos::parse( $min )->startOfDay() ) );
+		$this->assertTrue( $generated->lessThanOrEquals( Chronos::parse( $max )->endOfDay() ) );
+	}
+
+	/**
+	 * Verify that an invalid min date falls back to today rather than fataling.
+	 *
+	 * @test
+	 */
+	public function it_should_fall_back_to_today_when_min_is_invalid(): void {
+		$faker = $this->make_generator();
+
+		$result = $faker->meta_type_date(
+			[
+				'min' => 'not-a-date',
+				'max' => Chronos::today()->addDays( 30 )->toDateString(),
+			],
+			'Y-m-d H:i:s',
+			100
+		);
+
+		$this->assertIsString( $result );
+		$this->assertMatchesRegularExpression( '/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $result );
+	}
+
+	/**
+	 * Verify the route the Meta module actually takes — calling meta_type_date via
+	 * Faker's Generator::format, which is what triggered the original fatal in the
+	 * user's stack trace.
+	 *
+	 * @test
+	 */
+	public function it_should_handle_meta_type_date_via_faker_generator(): void {
+		$faker = $this->make_generator();
+
+		$result = $faker->format(
+			'meta_type_date',
+			[
+				[
+					'min' => '2021-06-01',
+					'max' => '2021-06-30',
+				],
+				'Y-m-d H:i:s',
+				100,
+			]
+		);
+
+		$this->assertIsString( $result );
+		$this->assertMatchesRegularExpression( '/^2021-06-\d{2} \d{2}:\d{2}:\d{2}$/', $result );
+	}
+}

--- a/tests/wpunit/Provider/WP_PostTest.php
+++ b/tests/wpunit/Provider/WP_PostTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Tests for the WP_Post Faker provider.
+ *
+ * Locks in the fix for the wp.org bug report:
+ * "Fatal error when using date option in meta field rules" where a preceding
+ * "Undefined property: stdClass::$terms" warning was emitted by WP_Post::tax_input
+ * when the supplied config did not include a `terms` key.
+ *
+ * @since 0.9.1
+ *
+ * @package FakerPress\Tests\Provider
+ */
+
+namespace FakerPress\Tests\Provider;
+
+use FakerPress\Provider\WP_Post;
+use FakerPress\ThirdParty\Faker\Factory;
+use FakerPress\ThirdParty\Faker\Generator;
+
+/**
+ * Class WP_PostTest
+ *
+ * @since 0.9.1
+ */
+class WP_PostTest extends \Codeception\TestCase\WPTestCase {
+
+	/**
+	 * Build a Faker generator with the WP_Post provider attached.
+	 *
+	 * @since 0.9.1
+	 *
+	 * @return Generator
+	 */
+	private function make_generator(): Generator {
+		$faker = Factory::create();
+		$faker->addProvider( new WP_Post( $faker ) );
+
+		return $faker;
+	}
+
+	/**
+	 * Verify that tax_input does not emit an "Undefined property" warning when the
+	 * config rows do not include `terms` or `taxonomies` keys.
+	 *
+	 * The original bug surfaced as:
+	 *   PHP Warning: Undefined property: stdClass::$terms in WP_Post.php on line 224
+	 *
+	 * @test
+	 */
+	public function it_should_handle_tax_input_config_without_terms_key(): void {
+		$faker = $this->make_generator();
+
+		$previous_handler = set_error_handler(
+			static function ( int $errno, string $errstr, string $errfile, int $errline ) {
+				throw new \ErrorException( $errstr, 0, $errno, $errfile, $errline );
+			},
+			E_WARNING | E_NOTICE | E_USER_WARNING | E_USER_NOTICE
+		);
+
+		try {
+			$result = $faker->tax_input(
+				[
+					[ 'taxonomies' => 'category' ],
+				]
+			);
+
+			$this->assertIsArray( $result );
+		} finally {
+			if ( null !== $previous_handler ) {
+				set_error_handler( $previous_handler );
+			} else {
+				restore_error_handler();
+			}
+		}
+	}
+
+	/**
+	 * Sanity: a fully empty config row should also not warn.
+	 *
+	 * @test
+	 */
+	public function it_should_handle_empty_tax_input_config_row(): void {
+		$faker = $this->make_generator();
+
+		$previous_handler = set_error_handler(
+			static function ( int $errno, string $errstr, string $errfile, int $errline ) {
+				throw new \ErrorException( $errstr, 0, $errno, $errfile, $errline );
+			},
+			E_WARNING | E_NOTICE | E_USER_WARNING | E_USER_NOTICE
+		);
+
+		try {
+			$result = $faker->tax_input( [ [] ] );
+			$this->assertIsArray( $result );
+		} finally {
+			if ( null !== $previous_handler ) {
+				set_error_handler( $previous_handler );
+			} else {
+				restore_error_handler();
+			}
+		}
+	}
+}

--- a/tests/wpunit/REST/PostsEndpointTest.php
+++ b/tests/wpunit/REST/PostsEndpointTest.php
@@ -198,4 +198,43 @@ class PostsEndpointTest extends \Codeception\TestCase\WPTestCase {
 			$this->assertSame( 'post', $post->post_type );
 		}
 	}
+
+	/**
+	 * Verify that a `date` meta rule generates a post and a valid meta value
+	 * without fataling on the missing Chronos import (wp.org bug report).
+	 *
+	 * @test
+	 */
+	public function it_should_generate_a_post_with_a_date_meta_field(): void {
+		$this->set_admin_user();
+
+		$response = $this->dispatch_rest_request(
+			'POST',
+			$this->route,
+			[
+				'quantity' => 1,
+				'meta'     => [
+					[
+						'type'     => 'date',
+						'name'     => 'fp_test_date_meta',
+						'interval' => [
+							'min' => '2020-01-01',
+							'max' => '2020-12-31',
+						],
+						'format'   => 'Y-m-d H:i:s',
+						'weight'   => 100,
+					],
+				],
+			]
+		);
+
+		$this->assert_success_response( $response );
+
+		$data    = $response->get_data();
+		$post_id = $data['data']['ids'][0];
+		$value   = get_post_meta( $post_id, 'fp_test_date_meta', true );
+
+		$this->assertNotEmpty( $value, 'Date meta value should be saved.' );
+		$this->assertMatchesRegularExpression( '/^2020-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $value );
+	}
 }


### PR DESCRIPTION
## Summary

- Adds the missing `use FakerPress\ThirdParty\Cake\Chronos\Chronos;` to `WP_Meta.php`, fixing a fatal that hit anyone using a `date`-type meta rule.
- Normalises `\$settings->taxonomies` / `\$settings->terms` to arrays inside `WP_Post::tax_input` so the array→stdClass cast does not emit "Undefined property" warnings on sparse configs (visible in the same stack trace under PHP 8.x).
- Adds focused regression tests (`WP_MetaTest`, `WP_PostTest`) and an end-to-end repro in `PostsEndpointTest` so the next refactor catches this immediately.

Refs wp.org support thread: https://wordpress.org/support/topic/fatal-error-when-using-date-option-in-meta-field-rules/

## Why this slipped through

`Chronos` was added to `WP_Post`, `WP_User`, and `WP_Comment` but the `use` line was forgotten in `WP_Meta`. PHP resolved the unqualified `Chronos` against the file's namespace, fataling with `Class "FakerPress\Provider\Chronos" not found`. The `tax_input` warning never crashed locally on older PHP but trips error displays under PHP 8.x with `display_errors` on.

There was no test that called `meta_type_date`, which is why the regression shipped.

## Test plan

- [x] `slic run wpunit` — 69 tests, 228 assertions, all green.
- [x] Manual: in `wp-admin/admin.php?page=fakerpress-posts`, add a Meta rule with type "Date", min/max set, click Generate; confirm a post is created and the meta value is a valid datetime string. Confirm `debug.log` shows no warnings or fatals.
- [x] `composer lint:php` against the touched source files — no new violations introduced.