### PR TITLE
fix: honor selected post_types on the Posts generate endpoint

### DIFF
--- a/src/FakerPress/REST/Endpoints/Posts.php
+++ b/src/FakerPress/REST/Endpoints/Posts.php
@@ -103,9 +103,18 @@ class Posts extends Abstract_Endpoint {
 		$params = $this->sanitize_request( $request );
 
 		// Translate REST params to module format.
-		if ( isset( $params['post_type'] ) ) {
-			$params['post_types'] = $params['post_type'];
+		// The admin form posts `post_types` (plural, the same key the module reads); the public
+		// REST schema also exposes a singular `post_type` alias. Accept whichever arrived and
+		// normalise to the comma-joined string the Post module expects.
+		$post_types_value = $params['post_types'] ?? $params['post_type'] ?? null;
+		if ( null !== $post_types_value ) {
+			if ( is_array( $post_types_value ) ) {
+				$post_types_value = implode( ',', array_map( 'strval', $post_types_value ) );
+			}
+			$params['post_types'] = (string) $post_types_value;
+			unset( $params['post_type'] );
 		}
+
 		if ( isset( $params['author_ids'] ) && is_array( $params['author_ids'] ) ) {
 			$params['author'] = implode( ',', $params['author_ids'] );
 		}
@@ -206,8 +215,15 @@ class Posts extends Abstract_Endpoint {
 						],
 					],
 				],
+				'post_types'  => [
+					'description' => __( 'Post types to sample from. Accepts an array of slugs or a comma-separated string.', 'fakerpress' ),
+					'type'        => [ 'array', 'string' ],
+					'items'       => [
+						'type' => 'string',
+					],
+				],
 				'post_type'   => [
-					'description' => __( 'Post type to generate.', 'fakerpress' ),
+					'description' => __( 'Deprecated singular alias for post_types — accepts a single post type slug.', 'fakerpress' ),
 					'type'        => 'string',
 					'default'     => 'post',
 				],

--- a/tests/wpunit/REST/PostsEndpointTest.php
+++ b/tests/wpunit/REST/PostsEndpointTest.php
@@ -237,4 +237,120 @@ class PostsEndpointTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertNotEmpty( $value, 'Date meta value should be saved.' );
 		$this->assertMatchesRegularExpression( '/^2020-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $value );
 	}
+
+	/**
+	 * Verify that the plural `post_types` parameter — the exact key the admin form
+	 * submits — generates posts of the requested type. Regression for the wp.org
+	 * report "Doesn't seem to create Pages now".
+	 *
+	 * @test
+	 */
+	public function it_should_generate_pages_when_post_types_plural_is_sent(): void {
+		$this->set_admin_user();
+
+		$response = $this->dispatch_rest_request(
+			'POST',
+			$this->route,
+			[
+				'quantity'   => 3,
+				'post_types' => 'page',
+			]
+		);
+
+		$this->assert_success_response( $response );
+
+		$data = $response->get_data();
+		$this->assertCount( 3, $data['data']['ids'] );
+
+		foreach ( $data['data']['ids'] as $post_id ) {
+			$post = get_post( $post_id );
+			$this->assertNotNull( $post );
+			$this->assertSame( 'page', $post->post_type );
+		}
+	}
+
+	/**
+	 * Verify that a comma-separated `post_types` value (admin form serialization)
+	 * samples across the requested types and never produces an unrequested type.
+	 *
+	 * @test
+	 */
+	public function it_should_accept_multiple_post_types_as_csv(): void {
+		$this->set_admin_user();
+
+		$response = $this->dispatch_rest_request(
+			'POST',
+			$this->route,
+			[
+				'quantity'   => 6,
+				'post_types' => 'page,post',
+			]
+		);
+
+		$this->assert_success_response( $response );
+
+		$data = $response->get_data();
+		$this->assertCount( 6, $data['data']['ids'] );
+
+		foreach ( $data['data']['ids'] as $post_id ) {
+			$post = get_post( $post_id );
+			$this->assertNotNull( $post );
+			$this->assertContains( $post->post_type, [ 'page', 'post' ] );
+		}
+	}
+
+	/**
+	 * Verify that an array-shaped `post_types` (used by JS clients that send
+	 * structured JSON) is also accepted.
+	 *
+	 * @test
+	 */
+	public function it_should_accept_post_types_as_array(): void {
+		$this->set_admin_user();
+
+		$response = $this->dispatch_rest_request(
+			'POST',
+			$this->route,
+			[
+				'quantity'   => 2,
+				'post_types' => [ 'page' ],
+			]
+		);
+
+		$this->assert_success_response( $response );
+
+		$data = $response->get_data();
+		foreach ( $data['data']['ids'] as $post_id ) {
+			$this->assertSame( 'page', get_post( $post_id )->post_type );
+		}
+	}
+
+	/**
+	 * Sending the plural `post_types` must take precedence over the singular
+	 * `post_type` alias (whose schema default is `post`). This is the exact bug:
+	 * the prior code overwrote `post_types` with `post_type`'s default and silently
+	 * generated posts instead of pages.
+	 *
+	 * @test
+	 */
+	public function it_should_prefer_post_types_over_singular_alias(): void {
+		$this->set_admin_user();
+
+		$response = $this->dispatch_rest_request(
+			'POST',
+			$this->route,
+			[
+				'quantity'   => 2,
+				'post_types' => 'page',
+				'post_type'  => 'post',
+			]
+		);
+
+		$this->assert_success_response( $response );
+
+		$data = $response->get_data();
+		foreach ( $data['data']['ids'] as $post_id ) {
+			$this->assertSame( 'page', get_post( $post_id )->post_type );
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Declares `post_types` (plural) as the canonical parameter on `POST /fakerpress/v1/posts/generate`, accepting either an array of slugs or a comma-separated string — matching what the admin form actually submits.
- Keeps `post_type` (singular) as a documented alias for older REST consumers, but stops letting its schema default (`post`) silently overwrite an explicitly-supplied `post_types` value.
- Adds four targeted regression tests covering the form serialization (CSV string), array payloads, multi-type sampling, and the precedence rule that pinned the bug.

Refs wp.org support thread: https://wordpress.org/support/topic/doesnt-seem-to-create-pages-now/

## Why this slipped through

The endpoint's existing test only ever exercised `post_type` (singular) — the alias the schema knew about. The admin form serializes its post-type dropdown as `post_types[]`/`post_types`, so live users hit a code path no test covered. Because the schema also defaulted the singular alias to `post`, the translation block in the handler kept clobbering the plural value with that default, and every generation came out as a Post regardless of selection.

## Test plan

- [x] `slic run wpunit` — 67 tests, 249 assertions, all green (4 new tests for this regression).
- [x] Manual: load \`wp-admin/admin.php?page=fakerpress-posts\`, deselect Post, select Page (optionally choose a parent), click Generate; confirm the generated items appear under \`wp-admin/edit.php?post_type=page\`.
- [x] `composer lint:php` against the changed file — no new violations introduced.